### PR TITLE
Updated arxiv prefselector, as arxiv PDF links do not end with .pdf anymore

### DIFF
--- a/extractors/prefselectors/arxiv.js
+++ b/extractors/prefselectors/arxiv.js
@@ -18,7 +18,7 @@ var BINPrefselector = ( function () {
 
   //function to obtain fallback url in case a pdf is loaded
   function getFallbackURL(url) {
-    return (url.search(/.*\.pdf[\s]*$/i) != -1 && url.search(/\/pdf\//i) != -1) ?  url.replace(/\/pdf\//i,"/abs/") : null;
+    return (url.search(/\/pdf\//i) != -1) ?  url.replace(/\/pdf\//i,"/abs/") : null;
   }
 
 	// finally expose selector message and link formatter


### PR DESCRIPTION
The arxiv PDF links do not have the .pdf extension anymore. Hence, currently, the prefselector for arxiv does not work and BibItNow reports that the bibtex cannot be extracted when viewing arxiv PDFs, instead of proposing to load the abs page.